### PR TITLE
Fix current page calc if all elements fit on screen

### DIFF
--- a/src/components/Carousel/Carousel.vue
+++ b/src/components/Carousel/Carousel.vue
@@ -26,7 +26,7 @@
           vs-carousel__arrows
           vs-carousel__arrows--left
         "
-        @click="goToSlide(currentPage - 1)"
+        @click="changeSlide(-1)"
       >
         ←
       </button>
@@ -40,7 +40,7 @@
           vs-carousel__arrows
           vs-carousel__arrows--right
         "
-        @click="goToSlide(currentPage + 1)"
+        @click="changeSlide(1)"
       >
         →
       </button>
@@ -237,6 +237,9 @@ export default {
         this.$refs.vsWrapper,
         { attributes: true, childList: true, characterData: true, subtree: true }
       )
+    },
+    changeSlide(direction) {
+      this.goToSlide(this.currentPage + direction)
     },
     goToSlide(index) {
       if (!this.slidesWidth[index]) {

--- a/src/components/Carousel/Carousel.vue
+++ b/src/components/Carousel/Carousel.vue
@@ -98,7 +98,6 @@ export default {
     wrapperVisibleWidth: 0,
     currentPage: 0,
     currentPos: 0,
-    maxPages: 0,
     step: 1,
     observer: null,
     onResizeFn: null,
@@ -141,9 +140,8 @@ export default {
       this.calcWrapperWidth()
       this.calcSlidesWidth()
       this.calcCurrentPosition()
-      this.calcCurrentPage()
+      this.setCurrentPage()
       this.calcBounds()
-      this.calcMaxPages()
     },
     calcOnScroll() {
       if (!this.$refs.vsWrapper) {
@@ -151,7 +149,7 @@ export default {
       }
 
       this.calcCurrentPosition()
-      this.calcCurrentPage()
+      this.setCurrentPage()
       this.calcBounds()
     },
     calcBounds() {
@@ -199,28 +197,36 @@ export default {
         width: node.offsetWidth
       }))
     },
-    calcCurrentPage() {
-      const getCurrentPage = this.slidesWidth.findIndex(slide => {
-        // Find the closest point, with 5px approximate.
+    getCurrentPage() {
+      // Last element if there is nothing left to scroll
+      if (approximatelyEqual(
+        this.currentPos + this.wrapperVisibleWidth,
+        this.wrapperScrollWidth,
+        5
+      )) {
+        return this.slidesWidth.length - 1
+      }
+
+      // Find slide closest to scroll position, with 5px approximate
+      return this.slidesWidth.findIndex(slide => {
         return approximatelyEqual(slide.offsetLeft, this.currentPos, 5)
       })
+    },
+    setCurrentPage(index) {
+      const newPage = index !== undefined ? index : this.getCurrentPage()
 
-      if (getCurrentPage < 0) {
+      if (newPage < 0) {
         return
       }
 
       const previous = this.currentPage
-      const current = getCurrentPage || 0
+      const current = newPage > 0 ? newPage : 0
 
       this.currentPage = current
       this.$emit('page', { current, previous })
     },
     calcCurrentPosition() {
       this.currentPos = this.$refs.vsWrapper.scrollLeft || 0
-    },
-    calcMaxPages() {
-      const maxPos = this.wrapperScrollWidth - this.wrapperVisibleWidth
-      this.maxPages = this.slidesWidth.findIndex(({ offsetLeft }) => offsetLeft > maxPos) - 1
     },
     calcNextWidth(direction) {
       const nextSlideIndex = direction > 0 ? this.currentPage : this.currentPage + direction
@@ -270,6 +276,8 @@ export default {
         left: this.slidesWidth[index].offsetLeft,
         behavior: 'smooth'
       })
+
+      this.setCurrentPage(index)
     }
   }
 }

--- a/src/components/Carousel/Carousel.vue
+++ b/src/components/Carousel/Carousel.vue
@@ -26,7 +26,7 @@
           vs-carousel__arrows
           vs-carousel__arrows--left
         "
-        @click="changeSlide(-1)"
+        @click="goToSlide(currentPage - 1)"
       >
         ←
       </button>
@@ -40,7 +40,7 @@
           vs-carousel__arrows
           vs-carousel__arrows--right
         "
-        @click="changeSlide(1)"
+        @click="goToSlide(currentPage + 1)"
       >
         →
       </button>
@@ -228,16 +228,6 @@ export default {
     calcCurrentPosition() {
       this.currentPos = this.$refs.vsWrapper.scrollLeft || 0
     },
-    calcNextWidth(direction) {
-      const nextSlideIndex = direction > 0 ? this.currentPage : this.currentPage + direction
-      const width = this.slidesWidth[nextSlideIndex].width || 0
-
-      if (!width) {
-        return
-      }
-
-      return width * direction
-    },
     attachMutationObserver() {
       this.observer = new MutationObserver(() => {
         this.calcOnInit()
@@ -247,25 +237,6 @@ export default {
         this.$refs.vsWrapper,
         { attributes: true, childList: true, characterData: true, subtree: true }
       )
-    },
-    changeSlide(direction) {
-      const leftBoundLimit = direction === -1 && this.boundLeft
-      const rightBoundLimit = direction === 1 && this.boundRight
-
-      if (leftBoundLimit || rightBoundLimit) {
-        return
-      }
-
-      const nextSlideWidth = this.calcNextWidth(direction)
-
-      if (!nextSlideWidth) {
-        return
-      }
-
-      this.$refs.vsWrapper.scrollBy({
-        left: nextSlideWidth,
-        behavior: 'smooth'
-      })
     },
     goToSlide(index) {
       if (!this.slidesWidth[index]) {


### PR DESCRIPTION
- get rid of unused `maxPages` and its calculation
- replace `changeSlide` with simpler `goToSlide`, for consistent behavior with exposed `go-to-page` API + removal of dependent method that is not in use anymore
- split getting current page index from setting it, supporting passing the index from outside, for example `goToSlide` method, so in some cases the index will change, even if there was no scroll event.
- fix support for calculating a proper current slide index, when there is nothing left to scroll