### PR TITLE
Remove component instance event listener when component unmounts

### DIFF
--- a/src/components/Carousel/Carousel.vue
+++ b/src/components/Carousel/Carousel.vue
@@ -157,7 +157,9 @@ export default {
       this.$refs.vsWrapper.addEventListener('scroll', this.onScrollFn)
       window.addEventListener('resize', this.onResizeFn, false)
 
-      this.$on('go-to-page', index => this.goToSlide(index))
+      const handleGoToPage = index => this.goToSlide(index);
+
+      this.$on('go-to-page', handleGoToPage)
 
       /**
        * Carousel mounted
@@ -165,6 +167,10 @@ export default {
        * @type {Event}
        */
       this.$emit('mounted', true)
+
+      this.$once('hook:beforeDestroy', () => {
+        this.$off('go-to-page', handleGoToPage);
+      });
     }
   },
   beforeDestroy() {


### PR DESCRIPTION
Hi 👋 
Thank you for this project.

The event listener on the Carousel component that listens for go-to-page events is not removed when the component unmounts. This can result in the buildup of unremoved event listeners leading to memory leaks. This PR fixes this issue. :)